### PR TITLE
Add transaction list endpoint

### DIFF
--- a/packages/api-library/index.js
+++ b/packages/api-library/index.js
@@ -1,49 +1,55 @@
 
+
+async* function genericList(pageSize, path) {
+  let cursor = null;
+  do {
+    const params = {};
+    if (cursor) {
+      params['cursor'] = cursor;
+    }
+    if (pageSize) {
+      params['page_size'] = pageSize;
+    }
+    let response;
+    try {
+      response = await this.client.get(path, {params});
+    }
+    catch (error) {
+      console.log(`Caught error while trying to get ${path} list.`);
+      if ('response' in error) {
+        console.dir(error.response.config.url, {depth:null, colors:true});
+        console.dir(error.response.config.headers, {depth:null, colors:true});
+        console.dir(error.response.status, {depth:null, colors:true});
+        console.dir(error.response.data, {depth:null, colors:true});
+      }
+      else {
+        console.log('Caught error without response:');
+        console.dir(error, {depth:null, colors:true});
+      }
+      return;
+    }
+    for (const result of response.data.results) {
+      yield result;
+    }
+    if (response.data.next != null) {
+      let nextUrl = new URL(response.data.next);
+      cursor = nextUrl.searchParams.get('cursor');
+      // TODO Figure out how to use the whole URL in `next` instead of this parsing.
+    }
+    else {
+      cursor = null;
+    }
+  } while (cursor != null);
+}
+
+
 class AssetsEndpoint {
   constructor(client) {
     this.client = client;
   }
 
   async* list(pageSize) {
-    let cursor = null;
-    do {
-      const params = {};
-      if (cursor) {
-        params['cursor'] = cursor;
-      }
-      if (pageSize) {
-        params['page_size'] = pageSize;
-      }
-      let response;
-      try {
-        response = await this.client.get('assets/', {params});
-      }
-      catch (error) {
-        console.log('Caught error while trying to get assets list.');
-        if ('response' in error) {
-          console.dir(error.response.config.url, {depth:null, colors:true});
-          console.dir(error.response.config.headers, {depth:null, colors:true});
-          console.dir(error.response.status, {depth:null, colors:true});
-          console.dir(error.response.data, {depth:null, colors:true});
-        }
-        else {
-          console.log('Caught error without response:');
-          console.dir(error, {depth:null, colors:true});
-        }
-        return;
-      }
-      for (const result of response.data.results) {
-        yield result;
-      }
-      if (response.data.next != null) {
-        let nextUrl = new URL(response.data.next);
-        cursor = nextUrl.searchParams.get('cursor');
-        // TODO Figure out how to use the whole URL in `next` instead of this parsing.
-      }
-      else {
-        cursor = null;
-      }
-    } while (cursor != null);
+    genericList(pageSize, 'assets/')
   }
 
   async retrieve(id) {
@@ -69,45 +75,7 @@ class WalletsEndpoint {
   }
 
   async* list(pageSize) {
-    let cursor = null;
-    do {
-      const params = {};
-      if (cursor) {
-        params['cursor'] = cursor;
-      }
-      if (pageSize) {
-        params['page_size'] = pageSize;
-      }
-      let response;
-      try {
-        response = await this.client.get('kms/wallets/', {params});
-      }
-      catch (error) {
-        console.log('Caught error while trying to get wallet list.');
-        if ('response' in error) {
-          console.dir(error.response.config.url, {depth:null, colors:true});
-          console.dir(error.response.config.headers, {depth:null, colors:true});
-          console.dir(error.response.status, {depth:null, colors:true});
-          console.dir(error.response.data, {depth:null, colors:true});
-        }
-        else {
-          console.log('Caught error without response:');
-          console.dir(error, {depth:null, colors:true});
-        }
-        return;
-      }
-      for (const result of response.data.results) {
-        yield result;
-      }
-      if (response.data.next != null) {
-        let nextUrl = new URL(response.data.next);
-        cursor = nextUrl.searchParams.get('cursor');
-        // TODO Figure out how to use the whole URL in `next` instead of this parsing.
-      }
-      else {
-        cursor = null;
-      }
-    } while (cursor != null);
+    genericList(pageSize, 'kms/wallets/')
   }
 
   async retrieve(id) {
@@ -132,6 +100,16 @@ class TransactionsEndpoint {
       fee:String(fee), // String because fee could be bigger than Number.MAX_SAFE_INTEGER
     };
     const response = await this.client.post(`kms/wallets/${walletId}/transactions/`, data);
+    return response.data;
+  }
+
+  async* list(pageSize, walletId) {
+    genericList(pageSize, `kms/wallets/${walletId}/transactions/`)
+  }
+
+  async retrieve(walletId, transactionId) {
+    const params = {};
+    const response = await this.client.get(`/wallets/${walletId}/transactions/${transactionId}`, params);
     return response.data;
   }
 }


### PR DESCRIPTION
This PR adds transaction listing functionality provided by the `kms/wallets/${walletId}/transactions/` 
endpoint. It uses the list/retrieve approach as the rest of the client.

Additionally I factored out the list functionality a-la boy scout to avoid code duplication. 

No tests, since `forward-transaction` functionality is in maintenance :). 

